### PR TITLE
Update role to split non ssl sites from ssl sites

### DIFF
--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -44,4 +44,4 @@
   with_together:
     - "{{ apache_vhosts_individual }}"
     - "{{ apache_ssl_certificates_individual.results }}"
-  when: apache_create_individual_vhosts
+  when: apache_create_vhosts

--- a/tasks/configure-Suse.yml
+++ b/tasks/configure-Suse.yml
@@ -14,9 +14,13 @@
   with_items: "{{ apache_vhosts_ssl }}"
 
 - name: Check whether certificates defined in vhosts exist for individual vhost configuration.
-  stat: path={{ item.certificate_file }}
+  stat:
+    path: "{{ item.certificate_file }}"
   register: apache_ssl_certificates_individual
+  when: item.certificate_file is defined
   with_items: "{{ apache_vhosts_individual }}"
+- debug:
+    var: apache_ssl_certificates_individual
 
 - name: Add apache vhosts configuration.
   template:
@@ -26,4 +30,17 @@
     group: root
     mode: 0644
   notify: restart apache
+  when: apache_create_vhosts
+
+- name: Add apache individual vhosts configuration.
+  template:
+    src: "{{ apache_vhosts_individual_template }}"
+    dest: "{{ apache_conf_path }}/{{ item.0.vhostname }}.{{ apache_vhost_filename_extension }}"
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart apache
+  with_together:
+    - "{{ apache_vhosts_individual }}"
+    - "{{ apache_ssl_certificates_individual.results }}"
   when: apache_create_vhosts

--- a/templates/vhosts.individual.conf.j2
+++ b/templates/vhosts.individual.conf.j2
@@ -1,6 +1,7 @@
 {{ apache_global_vhost_settings }}
 
 {# Set up VirtualHost #}
+{% if item.0.certificate_file is not defined %}
 <VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}>
   ServerName {{ item.0.servername }}
 {% if item.0.serveralias is defined %}
@@ -31,6 +32,7 @@
   {{ item.0.extra_parameters }}
 {% endif %}
 </VirtualHost>
+{% endif %}
 
 {# Set up SSL VirtualHost #}
 {% if item.0.certificate_file is defined %}


### PR DESCRIPTION
Updated role to split ssl from non ssl individual vhosts.
Also removed reference to apache_create_individual_vhosts as this flag was redundant. Instead tasks that were using that flag now use apache_create_vhosts flag.
Roles updated for Redhat and Suse.

Update reference to apache_create_individual_vhosts

Changed reference to apache_create_individual_vhosts so that it is now
just apache_create_vhosts.

Update individual template

Updated individual template to only create non-ssl vhost file if there is no
certificate_file defined in the individual vhost site list.